### PR TITLE
Adjust TP1 factor to 0.45 percent

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ POLL_SECS = 5
 TIMEOUT_HORAS = None   # e.g. 72 si quieres forzar salida tras X horas
 
 # Targets
-TP1_FACTOR = 1.005     # +0.5%  -> vende 50%
+TP1_FACTOR = 1.0045    # +0.45% -> vende 50%
 SL_FACTOR  = 0.990     # -1.0%  -> solo si NO tocó TP1
 
 # Break-even fee-aware (BNB activado: ~0.075% por lado)


### PR DESCRIPTION
## Summary
- reduce TP1_FACTOR threshold to trigger partial take-profit at +0.45%

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2be911a34832690586ee6efb5e392