### PR TITLE
Ensure lot size filters load before starting control thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,9 +90,6 @@ def cargar_filtros_lot_size(force: bool = False):
     }
     return _LOT_SIZE_CACHE
 
-
-cargar_filtros_lot_size()
-
 # ------------------ Utils ------------------
 def cargar_estado():
     with STATE_LOCK:
@@ -388,6 +385,7 @@ def unlock():
 # ------------------ Boot ------------------
 if __name__ == "__main__":
     print("🟢 Bot V7 (Modo B + Trailing + BuyLock) iniciado.")
+    cargar_filtros_lot_size(force=True)
     hilo = threading.Thread(target=control_venta, daemon=True)
     hilo.start()
     port = int(os.environ.get("PORT", 8080))


### PR DESCRIPTION
## Summary
- call `cargar_filtros_lot_size(force=True)` during startup before spawning the control thread
- drop the eager lot size fetch at import time so the forced refresh happens in the boot path

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68de58ab8dc0832683af9b31355dcfbc