### PR TITLE
Enhance Binance bot safety and configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,9 +10,17 @@ from flask import Flask, request, jsonify
 from binance.client import Client
 from binance.exceptions import BinanceAPIException
 
+# =================== Metadatos ===================
+BOT_VERSION = "V8.1.0"
+
 # =================== Config ===================
 PAIR = "BTCUSDC"
-JSON_FILE = os.getenv("STATE_FILE", "estado_compra.json")  # p.ej. /data/estado_compra.json con Volume
+JSON_FILE = os.getenv("STATE_FILE", "estado_compra.json")  # ej. /data/estado_compra.json con Volume
+
+# Loop
+POLL_SECS = float(os.getenv("POLL_SECS", "5"))
+_timeout_env = os.getenv("TIMEOUT_HORAS", "").strip()
+TIMEOUT_HORAS = float(_timeout_env) if _timeout_env else None
 
 # Timeframe & cooldown
 TF_INTERVAL = os.getenv("TF_INTERVAL", "1h")   # 1m,5m,15m,30m,1h,2h,4h
@@ -21,16 +29,14 @@ COOLDOWN_BARS = int(os.getenv("COOLDOWN_BARS", "2"))
 # ATR
 ATR_PERIOD = int(os.getenv("ATR_PERIOD", "14"))
 ATR_MULT = float(os.getenv("ATR_MULT", "1.0"))
+# SL mode: 'cap' => máximo 1.5% (por defecto), 'floor' => mínimo 1.5%
+SL_MODE = os.getenv("SL_MODE", "cap")
 
 # Targets solicitados
-TP_PCT = 0.02             # +2% TP fijo (cierra 100%)
-SL_MAX_PCT = 0.015        # -1.5% máximo (cap al SL por ATR)
-TRAIL_ON_PCT = 0.019      # +1.9% activación de trailing
-TRAIL_DIST_PCT = 0.01     # 1% de retroceso desde el pico
-
-# Poll loop
-POLL_SECS = 5
-TIMEOUT_HORAS = None  # opcional: forzar salida por tiempo
+TP_PCT = float(os.getenv("TP_PCT", "0.02"))        # +2% TP fijo (cierra 100%)
+SL_MAX_PCT = float(os.getenv("SL_MAX_PCT", "0.015"))  # 1.5% (cap o floor según SL_MODE)
+TRAIL_ON_PCT = float(os.getenv("TRAIL_ON_PCT", "0.019"))   # +1.9% activación de trailing
+TRAIL_DIST_PCT = float(os.getenv("TRAIL_DIST_PCT", "0.01")) # 1% de retroceso
 
 # LOT_SIZE (fallbacks; se sobreescriben con los reales al arrancar)
 STEP_SIZE = Decimal("0.000001")
@@ -39,7 +45,15 @@ DECIMAL_PLACES = 6
 _LOT_SIZE_CACHE = None
 
 # Compras
-QUOTE_BUFFER = 0.002   # 0.2% para evitar insufficient balance
+QUOTE_BUFFER = float(os.getenv("QUOTE_BUFFER", "0.002"))  # 0.2% para evitar insufficient balance
+
+# --- Fees / ventas seguras ---
+BNB_MIN = float(os.getenv("BNB_MIN", "0.01"))  # reserva mínima de BNB para comisiones
+SELL_SAFETY_PCT = Decimal(os.getenv("SELL_SAFETY_PCT", "0.002"))  # 0.2% si NO hay BNB
+
+# --- Auto-attach mínimos para evitar polvo que bloquee recompras ---
+ATTACH_MIN_MULT = Decimal(os.getenv("ATTACH_MIN_MULT", "1.2"))  # ≥ 1.2 * minQty
+ATTACH_MIN_USD  = Decimal(os.getenv("ATTACH_MIN_USD",  "5"))    # valor mínimo en USDC
 
 # Token opcional para /unlock
 UNLOCK_TOKEN = os.getenv("UNLOCK_TOKEN", "")
@@ -54,6 +68,9 @@ client = Client(
 def log(msg): print(msg, flush=True)
 
 STATE_LOCK = threading.Lock()
+_en_venta = threading.Lock()  # debounce ventas
+_last_watch_log = 0.0
+_last_attach_log = 0.0
 
 # =================== Helpers: timeframe ===================
 def _tf_to_binance(tf: str) -> str:
@@ -180,7 +197,6 @@ def _fetch_klines(limit: int = 100):
     return client.get_klines(symbol=PAIR, interval=interval, limit=limit)
 
 def _calc_atr(period: int = ATR_PERIOD):
-    """ATR simple (SMA) usando TR clásico. Devuelve ATR en unidades de precio."""
     kl = _fetch_klines(limit=max(period + 2, 20))
     if not kl or len(kl) < period + 1:
         px = obtener_precio_actual()
@@ -200,17 +216,27 @@ def _calc_atr(period: int = ATR_PERIOD):
 
 # =================== Trading core ===================
 def _calcular_niveles(entry):
-    atr = _calc_atr(ATR_PERIOD) * ATR_MULT         # ATR absoluto
+    atr = _calc_atr(ATR_PERIOD) * ATR_MULT
     sl_atr_price = entry - atr
     sl_cap_price = entry * (1 - SL_MAX_PCT)
-    sl_price = max(sl_atr_price, sl_cap_price)     # cap a -1.5% máximo
+
+    if SL_MODE == "floor":
+        # nunca más cerca que 1.5% (mínimo 1.5%)
+        sl_price = min(sl_atr_price, sl_cap_price)
+    else:
+        # por defecto: no más lejos que 1.5% (cap 1.5%)
+        sl_price = max(sl_atr_price, sl_cap_price)
+
     tp_price = entry * (1 + TP_PCT)
     trail_on_price = entry * (1 + TRAIL_ON_PCT)
+
+    atr_pct = atr / entry
+    log(f"SL calc -> ATR={atr:.2f} ({atr_pct:.2%}), cap1.5%={sl_cap_price:.2f}, SL final={sl_price:.2f}")
+
     return {"atr_abs": atr, "sl_price": sl_price, "tp_price": tp_price, "trail_on_price": trail_on_price}
 
 def comprar_100(uid=None):
     st = cargar_estado()
-    # Cooldown activo?
     cd_until = st.get("cooldown_until")
     if cd_until and datetime.now() < datetime.fromisoformat(cd_until):
         log(f"⏳ BUY ignorado por cooldown hasta {cd_until}."); return
@@ -219,7 +245,6 @@ def comprar_100(uid=None):
     if uid and st.get("last_uid") == uid:
         log("ℹ️ Alerta duplicada ignorada por uid."); return
 
-    # Si ya hay BTC en wallet (tras reinicio), adjuntar en vez de recomprar
     cargar_filtros_lot_size()
     if normalizar_cantidad(get_free("BTC")) >= MIN_QTY:
         auto_attach_from_wallet()
@@ -230,7 +255,11 @@ def comprar_100(uid=None):
         log(f"⚠️ USDC insuficiente ({usdc})."); return
 
     usdc_to_spend = usdc * (1.0 - QUOTE_BUFFER)
-    orden = client.order_market_buy(symbol=PAIR, quoteOrderQty=round(usdc_to_spend, 2))
+    orden = client.order_market_buy(
+        symbol=PAIR,
+        quoteOrderQty=round(usdc_to_spend, 2),
+        newClientOrderId=f"MINADOR_BUY_{int(time.time())}"
+    )
 
     fills = orden.get("fills", [])
     if fills:
@@ -264,24 +293,90 @@ def comprar_100(uid=None):
     guardar_estado(st, origin="comprar_100")
     log(f"✅ COMPRA: {qty_exec_float:.8f} BTC @ {avg_px:.2f} | TP {lv['tp_price']:.2f} | SL {lv['sl_price']:.2f} | TrailON {lv['trail_on_price']:.2f}")
 
+# ---- helpers de venta ----
+def qty_vendible_segura(deseada: Decimal | None = None) -> Decimal:
+    """
+    Máximo que puedo vender ahora mismo:
+    - Usa BTC libre real.
+    - Si no hay BNB suficiente, deja % de colchón para fee en BTC.
+    - Deja siempre 1 step de seguridad.
+    - Ajusta a step/minQty.
+    - Fuerza que el leftover quede < MIN_QTY (para no bloquear recompras).
+    """
+    free = Decimal(str(get_free("BTC")))
+    if free <= 0:
+        return Decimal("0")
+
+    free_bnb = Decimal(str(get_free("BNB")))
+    cushion = STEP_SIZE if free_bnb >= Decimal(str(BNB_MIN)) else max((free * SELL_SAFETY_PCT), STEP_SIZE)
+
+    target = free - cushion
+    if deseada is not None:
+        target = min(target, Decimal(str(deseada)))
+
+    q = normalizar_cantidad(target)
+    if q <= 0:
+        return Decimal("0")
+
+    leftover = free - q
+    if leftover >= MIN_QTY:
+        q2 = free - (MIN_QTY - STEP_SIZE)  # deja ~minQty - step
+        if deseada is not None:
+            q2 = min(q2, Decimal(str(deseada)))
+        q = normalizar_cantidad(q2)
+
+    return q if q >= MIN_QTY else Decimal("0")
+
 def vender_qty(qty):
-    qty = normalizar_cantidad(qty)
-    if qty <= 0: return None
-    qty_str = formatear_cantidad(qty)
-    try:
-        return client.order_market_sell(symbol=PAIR, quantity=qty_str)
-    except BinanceAPIException as e:
-        if e.code == -1013 and "LOT_SIZE" in str(e):
-            cargar_filtros_lot_size(force=True)
-            qty2 = normalizar_cantidad(qty)
-            if qty2 <= 0:
-                log("⚠️ Qty < minQty tras recargar filtros. Nada que vender.")
+    """
+    Market sell robusto:
+    - Ajusta a free BTC real + colchón (fees/redondeos).
+    - Si no hay BNB, deja % de seguridad en BTC.
+    - Reintenta ante:
+        * -2010 insufficient balance -> recalcula vendible y reduce 0.1% + 1 step.
+        * -1013 LOT_SIZE -> recarga filtros y re-normaliza.
+    """
+    q = qty_vendible_segura(Decimal(str(qty)))
+    if q <= 0:
+        return None
+
+    def _try(q_):
+        return client.order_market_sell(
+            symbol=PAIR,
+            quantity=formatear_cantidad(q_),
+            newClientOrderId=f"MINADOR_SELL_{int(time.time())}"
+        )
+
+    intentos = 0
+    while intentos < 3:
+        intentos += 1
+        try:
+            return _try(q)
+        except BinanceAPIException as e:
+            msg = str(e)
+            if e.code == -2010 and "insufficient" in msg.lower():
+                nuevo = qty_vendible_segura()
+                if nuevo <= 0 or nuevo >= q:
+                    nuevo = normalizar_cantidad(q * Decimal("0.999") - STEP_SIZE)
+                if nuevo >= MIN_QTY:
+                    log(f"↻ Reintento (-2010) con qty={formatear_cantidad(nuevo)}")
+                    q = nuevo
+                    continue
+                log("⚠️ -2010 y resto < minQty. Nada que vender.")
                 return None
-            qty2_str = formatear_cantidad(qty2)
-            log(f"↻ Reintento venta LOT_SIZE con qty={qty2_str}")
-            return client.order_market_sell(symbol=PAIR, quantity=qty2_str)
-        else:
-            log(f"❌ BinanceAPIException en vender_qty: {e}"); raise
+            if e.code == -1013 and "LOT_SIZE" in msg:
+                cargar_filtros_lot_size(force=True)
+                nuevo = qty_vendible_segura(q)
+                if nuevo >= MIN_QTY:
+                    log(f"↻ Reintento (-1013 LOT_SIZE) con qty={formatear_cantidad(nuevo)}")
+                    q = nuevo
+                    continue
+                log("⚠️ -1013 y qty < minQty. Nada que vender.")
+                return None
+            log(f"❌ BinanceAPIException en vender_qty: {e}")
+            raise
+    log("⚠️ Venta abortada tras 3 reintentos.")
+    return None
 
 def _aplicar_cooldown(st):
     secs = _tf_seconds(TF_INTERVAL) * COOLDOWN_BARS
@@ -291,41 +386,60 @@ def _aplicar_cooldown(st):
     log(f"⏳ Cooldown activado {COOLDOWN_BARS} velas ({TF_INTERVAL}) hasta {st['cooldown_until']}.")
 
 def _cerrar_todo(st, motivo="Exit"):
-    qty_rest = float(st.get("qty_restante", 0.0))
-    if qty_rest <= 0: qty_rest = get_free("BTC")
-    qty_rest = normalizar_cantidad(qty_rest)
-    if qty_rest <= 0:
-        log(f"ℹ️ Nada vendible ({motivo}). Posible dust < minQty. Libero lock + cooldown.")
-        lock_off()
-        st = cargar_estado(); _aplicar_cooldown(st)
+    if not _en_venta.acquire(blocking=False):
+        log("⏳ Venta ya en curso. Ignoro señal duplicada.")
         return
-    orden = vender_qty(qty_rest)
-    desbloquear = True
-    if orden:
-        executed_qty = normalizar_cantidad(orden.get("executedQty", 0.0))
-        st["qty_restante"] = max(0.0, float(st.get("qty_restante", 0.0)) - float(executed_qty))
-        guardar_estado(st, origin=f"close_{motivo}")
-        if st["qty_restante"] > 0:
-            desbloquear = False
-            log(f"⚠️ Venta parcial ({motivo}): quedan {formatear_cantidad(st['qty_restante'])} BTC")
+    try:
+        qty_estado = Decimal(str(st.get("qty_restante", 0.0)))
+        qty_wallet = Decimal(str(get_free("BTC")))
+        qty_target = max(qty_estado, qty_wallet)
+
+        qty_sell = qty_vendible_segura(qty_target)
+        if qty_sell <= 0:
+            log(f"ℹ️ Nada vendible ({motivo}). Posible dust < minQty. Libero lock + cooldown.")
+            lock_off()
+            st2 = cargar_estado(); _aplicar_cooldown(st2)
+            return
+
+        orden = vender_qty(qty_sell)
+        desbloquear = True
+        if orden:
+            executed_qty = normalizar_cantidad(orden.get("executedQty", 0.0))
+            st["qty_restante"] = max(0.0, float(st.get("qty_restante", 0.0)) - float(executed_qty))
+            guardar_estado(st, origin=f"close_{motivo}")
+            if st["qty_restante"] > 0:
+                desbloquear = False
+                log(f"⚠️ Venta parcial ({motivo}): quedan {formatear_cantidad(st['qty_restante'])} BTC")
+            else:
+                log(f"✅ CIERRE TOTAL ({motivo}): {formatear_cantidad(executed_qty)} BTC")
         else:
-            log(f"✅ CIERRE TOTAL ({motivo}): {formatear_cantidad(executed_qty)} BTC")
-    else:
-        log(f"⚠️ Venta fallida ({motivo}).")
-    if not desbloquear and float(st.get("qty_restante", 0.0)) < float(MIN_QTY):
-        log("ℹ️ Resto < minQty (dust). Libero lock."); desbloquear = True
-    if desbloquear:
-        lock_off()
-        st = cargar_estado(); _aplicar_cooldown(st)
+            log(f"⚠️ Venta fallida ({motivo}).")
+        if not desbloquear and float(st.get("qty_restante", 0.0)) < float(MIN_QTY):
+            log("ℹ️ Resto < minQty (dust). Libero lock."); desbloquear = True
+        if desbloquear:
+            lock_off()
+            st2 = cargar_estado(); _aplicar_cooldown(st2)
+    finally:
+        _en_venta.release()
 
 # =================== Auto-attach (blindado) ===================
 def auto_attach_from_wallet():
-    # Asegura LOT_SIZE real (MIN_QTY correcto) antes de decidir
+    global _last_attach_log
     cargar_filtros_lot_size()
-    qty_wallet_raw = get_free("BTC")
+    qty_wallet_raw = Decimal(str(get_free("BTC")))
     qty_wallet = normalizar_cantidad(qty_wallet_raw)
-    if qty_wallet <= 0 or qty_wallet < MIN_QTY:
-        log(f"🔎 Auto-attach: nada que adjuntar (wallet={qty_wallet_raw:.8f} < minQty {MIN_QTY})")
+
+    attach_min_qty = max(MIN_QTY * ATTACH_MIN_MULT, STEP_SIZE * 3)
+    px = Decimal(str(obtener_precio_actual()))
+    usd_val = qty_wallet * px
+
+    if qty_wallet < attach_min_qty or usd_val < ATTACH_MIN_USD:
+        # throttle de log: 60s
+        if time.time() - _last_attach_log > 60:
+            log(
+                f"🔎 Auto-attach: nada que adjuntar (wallet={qty_wallet_raw:.8f} < minQty {attach_min_qty} o ${ATTACH_MIN_USD})"
+            )
+            _last_attach_log = time.time()
         return
 
     st = cargar_estado()
@@ -339,7 +453,7 @@ def auto_attach_from_wallet():
                 total_qty += q; spent += q * p
                 if total_qty >= float(qty_wallet) * 0.98:
                     break
-        entry = spent / total_qty if total_qty > 0 else obtener_precio_actual()
+        entry = spent / total_qty if total_qty > 0 else float(px)
         lv = _calcular_niveles(entry)
         st.update({
             "operacion_abierta": True, "buy_lock": True, "last_uid": None,
@@ -355,11 +469,9 @@ def auto_attach_from_wallet():
         log(f"⚠️ Auto-attach falló: {e}")
 
 # =================== Monitor ===================
-_last_watch_log = 0.0
-
 def control_venta():
     global _last_watch_log
-    log("🚀 Iniciando control (TP2%, SL ATR≤1.5%, Trailing 1.9%/1%, Cooldown 2 velas)…")
+    log("🚀 Iniciando control (TP2%, SL ATR≤1.5% [cap/floor], Trailing 1.9%/1%, Cooldown 2 velas)…")
     reconciliar_estado()
     while True:
         try:
@@ -379,30 +491,29 @@ def control_venta():
                 sl = float(st["sl_price"])
                 trail_on = float(st["trail_on_price"])
 
-                # log WATCH cada 30 s
                 now = time.time()
                 if now - _last_watch_log > 30:
                     log(f"👀 WATCH | px={px:.2f} entry={entry:.2f} TP@{tp:.2f} SL@{sl:.2f} TrailON@{trail_on:.2f} trail_active={st.get('trail_active')} peak={st.get('trail_peak')}")
                     _last_watch_log = now
 
-                # Timeout opcional
                 if TIMEOUT_HORAS is not None:
                     t0 = datetime.fromisoformat(st["hora_compra"])
                     if datetime.now() - t0 > timedelta(hours=TIMEOUT_HORAS):
+                        log("⏰ Timeout forzado")
                         _cerrar_todo(st, "Timeout")
                         time.sleep(POLL_SECS); continue
 
-                # 1) Stop Loss (siempre activo)
+                # 1) Stop Loss
                 if px <= sl:
-                    log("🛑 SL por ATR (cap 1.5%)")
+                    log("🛑 SL por ATR")
                     _cerrar_todo(st, "StopLoss"); time.sleep(POLL_SECS); continue
 
-                # 2) Take Profit fijo 2%
+                # 2) Take Profit +2%
                 if px >= tp:
                     log("🎯 TP +2% alcanzado")
                     _cerrar_todo(st, "TakeProfit"); time.sleep(POLL_SECS); continue
 
-                # 3) Trailing logic
+                # 3) Trailing
                 if not st.get("trail_active"):
                     if px >= trail_on:
                         st["trail_active"] = True
@@ -432,7 +543,6 @@ def webhook():
     data = request.get_json(silent=True) or {}
     if data.get("action") == "buy":
         st = cargar_estado()
-        # cooldown activo -> ignorar
         cd_until = st.get("cooldown_until")
         if cd_until and datetime.now() < datetime.fromisoformat(cd_until):
             log(f"⏳ BUY ignorado por cooldown hasta {cd_until}.")
@@ -440,7 +550,6 @@ def webhook():
         if st.get("buy_lock") or st.get("operacion_abierta"):
             log("🔒 BUY ignorado: operación aún no cerrada.")
             return jsonify({"status": "ignored_locked"})
-        # si hay BTC en wallet, adjuntar en lugar de recomprar
         cargar_filtros_lot_size()
         if normalizar_cantidad(get_free("BTC")) >= MIN_QTY:
             auto_attach_from_wallet()
@@ -456,13 +565,14 @@ def status():
     try: price = obtener_precio_actual()
     except Exception: pass
     return jsonify({
-        "alive": True, "pair": PAIR, "price": price, "state": st,
+        "alive": True, "version": BOT_VERSION, "pair": PAIR, "price": price, "state": st,
         "lot_size": {"stepSize": str(STEP_SIZE), "minQty": str(MIN_QTY), "decimals": DECIMAL_PLACES},
         "config": {
             "TF_INTERVAL": TF_INTERVAL, "COOLDOWN_BARS": COOLDOWN_BARS,
-            "ATR_PERIOD": ATR_PERIOD, "ATR_MULT": ATR_MULT,
+            "ATR_PERIOD": ATR_PERIOD, "ATR_MULT": ATR_MULT, "SL_MODE": SL_MODE,
             "TP_PCT": TP_PCT, "SL_MAX_PCT": SL_MAX_PCT,
-            "TRAIL_ON_PCT": TRAIL_ON_PCT, "TRAIL_DIST_PCT": TRAIL_DIST_PCT
+            "TRAIL_ON_PCT": TRAIL_ON_PCT, "TRAIL_DIST_PCT": TRAIL_DIST_PCT,
+            "POLL_SECS": POLL_SECS, "TIMEOUT_HORAS": TIMEOUT_HORAS
         }
     })
 
@@ -480,20 +590,17 @@ def unlock():
 # =================== Boot ===================
 if __name__ == "__main__":
     try:
-        log("🟢 Bot V8 (TP2% / SL ATR≤1.5% / Trail 1.9%–1% / Cooldown 2 velas) iniciando…")
-        log(f"ENV PORT={os.environ.get('PORT')}  PAIR={PAIR}  STATE_FILE={JSON_FILE}  TF={TF_INTERVAL}")
-
-        # 1) LOT_SIZE ANTES del hilo (parche)
+        log(f"🟢 Bot {BOT_VERSION} (TP2% / SL ATR[{SL_MODE}]≤1.5% / Trail 1.9%–1% / Cooldown 2 velas) iniciando…")
+        log(f"ENV PORT={os.environ.get('PORT')}  PAIR={PAIR}  STATE_FILE={JSON_FILE}  TF={TF_INTERVAL}  POLL={POLL_SECS}s")
+        # 1) LOT_SIZE ANTES del hilo
         try:
             cfg = cargar_filtros_lot_size(force=True)
             log(f"ℹ️ LOT_SIZE: step={cfg['stepSize']}, minQty={cfg['minQty']}, decimals={cfg['decimals']}")
         except Exception as e:
             log(f"⚠️ No se pudo cargar LOT_SIZE en arranque: {e}")
-
-        # 2) Arranco el hilo de control
+        # 2) Hilo de control
         hilo = threading.Thread(target=control_venta, daemon=True)
         hilo.start()
-
         # 3) Flask
         port = int(os.environ.get("PORT", 8080))
         app.run(host="0.0.0.0", port=port, debug=False)
@@ -501,4 +608,3 @@ if __name__ == "__main__":
         log(f"❌ Error fatal en arranque: {e}")
         import traceback; traceback.print_exc()
         sys.exit(1)
-


### PR DESCRIPTION
## Summary
- add environment-driven configuration for polling, ATR stops, and timeouts while bumping bot metadata
- harden selling pipeline with real balance checks, dust prevention, retries, and debounced exits
- tighten auto-attach and webhook flows to avoid small residuals and label orders consistently

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e54306cf648326b7d94a0e3767195f